### PR TITLE
Feat : 회원가입 API 구현

### DIFF
--- a/src/main/java/com/onlymeal/domain/user/controller/AuthController.java
+++ b/src/main/java/com/onlymeal/domain/user/controller/AuthController.java
@@ -1,0 +1,24 @@
+package com.onlymeal.domain.user.controller;
+
+import com.onlymeal.domain.user.dto.SignupRequest;
+import com.onlymeal.domain.user.service.UserService;
+import com.onlymeal.global.common.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/auth")
+@RequiredArgsConstructor
+public class AuthController {
+
+    private final UserService userService;
+
+    @PostMapping("/signup")
+    public ApiResponse<Void> signup(@RequestBody SignupRequest request) {
+        userService.signup(request);
+        return ApiResponse.success(null);
+    }
+}

--- a/src/main/java/com/onlymeal/domain/user/dao/UserDao.java
+++ b/src/main/java/com/onlymeal/domain/user/dao/UserDao.java
@@ -1,0 +1,11 @@
+package com.onlymeal.domain.user.dao;
+
+import com.onlymeal.domain.user.dto.SignupRequest;
+import com.onlymeal.domain.user.entity.User;
+import org.apache.ibatis.annotations.Mapper;
+
+@Mapper
+public interface UserDao {
+    void insertUser(SignupRequest request);
+    User getUserByEmail(String email);
+}

--- a/src/main/java/com/onlymeal/domain/user/dto/SignupRequest.java
+++ b/src/main/java/com/onlymeal/domain/user/dto/SignupRequest.java
@@ -1,0 +1,20 @@
+package com.onlymeal.domain.user.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class SignupRequest {
+    private String email;
+    private String password;
+    private String nickname;
+    private String gender;
+    private String birthDate;
+    private Double height;
+    private Double weight;
+    private String activityLevel;
+    private String targetGoal;
+}

--- a/src/main/java/com/onlymeal/domain/user/entity/User.java
+++ b/src/main/java/com/onlymeal/domain/user/entity/User.java
@@ -1,0 +1,22 @@
+package com.onlymeal.domain.user.entity;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class User {
+    private Long userId;
+    private String email;
+    private String password;
+    private String nickname;
+    private String gender;
+    private String birthDate;
+    private Double height;
+    private Double weight;
+    private String activityLevel;
+    private String targetGoal;
+    private String coachTone;
+    private String coachPersonality;
+    private String createdAt;
+}

--- a/src/main/java/com/onlymeal/domain/user/service/UserService.java
+++ b/src/main/java/com/onlymeal/domain/user/service/UserService.java
@@ -1,0 +1,26 @@
+package com.onlymeal.domain.user.service;
+
+import com.onlymeal.domain.user.dao.UserDao;
+import com.onlymeal.domain.user.dto.SignupRequest;
+import com.onlymeal.global.exception.CustomException;
+import com.onlymeal.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserService {
+
+    private final UserDao userDao;
+    private final PasswordEncoder passwordEncoder;
+
+    public void signup(SignupRequest request) {
+        if (userDao.getUserByEmail(request.getEmail()) != null) {
+            throw new CustomException(ErrorCode.DUPLICATE_EMAIL);
+        }
+
+        request.setPassword(passwordEncoder.encode(request.getPassword()));
+        userDao.insertUser(request);
+    }
+}

--- a/src/main/java/com/onlymeal/global/common/ApiResponse.java
+++ b/src/main/java/com/onlymeal/global/common/ApiResponse.java
@@ -1,17 +1,19 @@
 package com.onlymeal.global.common;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.Getter;
 
+@JsonInclude(JsonInclude.Include.NON_NULL)
 @Getter
 public class ApiResponse<T> {
     private final boolean success;
     private final T data;
-    private final String message;
+    private final ErrorResponse error;
 
-    public ApiResponse(boolean success, T data, String message) {
+    public ApiResponse(boolean success, T data, ErrorResponse error) {
         this.success = success;
         this.data = data;
-        this.message = message;
+        this.error = error;
     }
 
     public static <T> ApiResponse<T> success(T data) {
@@ -22,7 +24,7 @@ public class ApiResponse<T> {
         return new ApiResponse<>(true, null, null);
     }
 
-    public static ApiResponse<Void> failure(String message) {
-        return new ApiResponse<>(false, null, message);
+    public static ApiResponse<Void> failure(String code, String message) {
+        return new ApiResponse<>(false, null, new ErrorResponse(code, message));
     }
 }

--- a/src/main/java/com/onlymeal/global/common/ErrorResponse.java
+++ b/src/main/java/com/onlymeal/global/common/ErrorResponse.java
@@ -1,0 +1,11 @@
+package com.onlymeal.global.common;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class ErrorResponse {
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/onlymeal/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/onlymeal/global/exception/GlobalExceptionHandler.java
@@ -10,15 +10,16 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(CustomException.class)
     public ResponseEntity<ApiResponse<Void>> handleCustomException(CustomException e) {
+        ErrorCode errorCode = e.getErrorCode();
         return ResponseEntity
                 .status(e.getErrorCode().getStatus())
-                .body(ApiResponse.failure(e.getErrorCode().getMessage()));
+                .body(ApiResponse.failure(errorCode.name(), errorCode.getMessage()));
     }
 
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ApiResponse<Void>> handleException(Exception e) {
         return ResponseEntity
                 .status(500)
-                .body(ApiResponse.failure("서버 오류가 발생했습니다"));
+                .body(ApiResponse.failure("INTERNAL_ERROR", "서버 오류가 발생했습니다"));
     }
 }

--- a/src/main/resources/mappers/UserDao.xml
+++ b/src/main/resources/mappers/UserDao.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="com.onlymeal.domain.user.dao.UserDao">
+
+    <insert id="insertUser">
+        INSERT INTO users (email, password, nickname, gender, birth_date, height, weight, activity_level, target_goal)
+        VALUES (#{email}, #{password}, #{nickname}, #{gender}, #{birthDate}, #{height}, #{weight}, #{activityLevel}, #{targetGoal})
+    </insert>
+
+    <select id="getUserByEmail" resultType="User">
+        SELECT *
+        FROM users
+        WHERE email = #{email}
+    </select>
+
+</mapper>


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- #[Issue number]
- close : #13 
<!-- 이슈 완료되었을 때만 close 붙여주세요 --> 

## ✅ 작업 내용
<!-- 이번 PR에서 작업한 내용을 설명해 주세요 -->
- 회원가입 API 구현
- ApiResponse null 필드 제외 및 에러 응답 구조 변경

## 📸 스크린샷 
<!-- 실행 결과를 첨부해 주세요 -->
### 성공
<img width="1550" height="966" alt="image" src="https://github.com/user-attachments/assets/6f852cda-666e-401f-b5e1-016b8adfe7e8" />

### 실패
 
<img width="1528" height="456" alt="image" src="https://github.com/user-attachments/assets/9ae227b7-bcfe-4114-a011-77df3f823436" />


## 🗨️ 참고 사항
<!-- 특별히 봐주었으면 하는 부분과 참고해야 할 사항이 있다면 작성해 주세요 -->
<!-- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->