### PR TITLE
Feat: 음식 검색 API 구현

### DIFF
--- a/src/main/java/com/onlymeal/domain/food/controller/FoodController.java
+++ b/src/main/java/com/onlymeal/domain/food/controller/FoodController.java
@@ -1,0 +1,26 @@
+package com.onlymeal.domain.food.controller;
+
+import com.onlymeal.domain.food.dto.FoodDetailResponse;
+import com.onlymeal.domain.food.service.FoodService;
+import com.onlymeal.global.common.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/foods")
+@RequiredArgsConstructor
+public class FoodController {
+
+    private final FoodService foodService;
+
+    @GetMapping("/search")
+    public ApiResponse<List<FoodDetailResponse>> searchFood(
+            @RequestParam String keyword,
+            @RequestParam(defaultValue = "10") int limit) {
+
+        List<FoodDetailResponse> response = foodService.searchFood(keyword, limit);
+        return ApiResponse.success(response);
+    }
+}

--- a/src/main/java/com/onlymeal/domain/food/dao/FoodDao.java
+++ b/src/main/java/com/onlymeal/domain/food/dao/FoodDao.java
@@ -1,0 +1,12 @@
+package com.onlymeal.domain.food.dao;
+
+import com.onlymeal.domain.food.entity.Food;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+import java.util.List;
+
+@Mapper
+public interface FoodDao {
+    List<Food> searchFoods(@Param("keyword") String keyword, @Param("limit") int limit);
+}

--- a/src/main/java/com/onlymeal/domain/food/dto/FoodDetailResponse.java
+++ b/src/main/java/com/onlymeal/domain/food/dto/FoodDetailResponse.java
@@ -1,0 +1,33 @@
+package com.onlymeal.domain.food.dto;
+
+import com.onlymeal.domain.food.entity.Food;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class FoodDetailResponse {
+    private Long foodId;
+    private String foodName;
+    private Double servingUnitG;
+    private Double caloriesKcal;
+    private Double carbsG;
+    private Double proteinG;
+    private Double fatG;
+    private Double sugarsG;
+    private Double sodiumMg;
+
+    public static FoodDetailResponse from(Food food) {
+        return FoodDetailResponse.builder()
+                .foodId(food.getFoodId())
+                .foodName(food.getFoodName())
+                .servingUnitG(food.getServingUnitG())
+                .caloriesKcal(food.getCaloriesKcal())
+                .carbsG(food.getCarbsG())
+                .proteinG(food.getProteinG())
+                .fatG(food.getFatG())
+                .sugarsG(food.getSugarsG())
+                .sodiumMg(food.getSodiumMg())
+                .build();
+    }
+}

--- a/src/main/java/com/onlymeal/domain/food/entity/Food.java
+++ b/src/main/java/com/onlymeal/domain/food/entity/Food.java
@@ -1,0 +1,20 @@
+package com.onlymeal.domain.food.entity;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class Food {
+    private Long foodId;
+    private String foodName;
+    private Double servingUnitG;
+    private Double caloriesKcal;
+    private Double carbsG;
+    private Double proteinG;
+    private Double fatG;
+    private Double sugarsG;
+    private Double sodiumMg;
+}

--- a/src/main/java/com/onlymeal/domain/food/service/FoodService.java
+++ b/src/main/java/com/onlymeal/domain/food/service/FoodService.java
@@ -1,0 +1,31 @@
+package com.onlymeal.domain.food.service;
+
+import com.onlymeal.domain.food.dao.FoodDao;
+import com.onlymeal.domain.food.dto.FoodDetailResponse;
+import com.onlymeal.domain.food.entity.Food;
+import com.onlymeal.global.exception.CustomException;
+import com.onlymeal.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class FoodService {
+
+    private final FoodDao foodDao;
+
+    public List<FoodDetailResponse> searchFood(String keyword, int limit) {
+        if (keyword == null || keyword.isBlank()) {
+            throw new CustomException(ErrorCode.KEYWORD_REQUIRED);
+        }
+
+        List<Food> foods = foodDao.searchFoods(keyword, limit);
+
+        return foods.stream()
+                .map(FoodDetailResponse::from)
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/onlymeal/global/exception/ErrorCode.java
+++ b/src/main/java/com/onlymeal/global/exception/ErrorCode.java
@@ -26,6 +26,7 @@ public enum ErrorCode {
 
     // Food
     FOOD_NOT_FOUND(HttpStatus.NOT_FOUND, "음식 정보를 찾을 수 없습니다"),
+    KEYWORD_REQUIRED(HttpStatus.BAD_REQUEST, "검색어는 필수입니다"),
 
     // Common
     INVALID_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 요청입니다"),

--- a/src/main/resources/mappers/FoodDao.xml
+++ b/src/main/resources/mappers/FoodDao.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="com.onlymeal.domain.food.dao.FoodDao">
+
+    <select id="searchFoods" resultType="Food">
+        SELECT *
+        FROM foods
+        WHERE MATCH(food_name) AGAINST(CONCAT(#{keyword}, '*') IN BOOLEAN MODE)
+            LIMIT #{limit}
+    </select>
+
+</mapper>


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- closes : #26 
<!-- 이슈 완료되었을 때만 close 붙여주세요 --> 

## ✅ 작업 내용
<!-- 이번 PR에서 작업한 내용을 설명해 주세요 -->
- 음식 검색 API 구현
- DB에 Food 전처리 데이터 삽입

## 📸 스크린샷 
<!-- 실행 결과를 첨부해 주세요 -->

### 데이터
<img width="1493" height="825" alt="image" src="https://github.com/user-attachments/assets/87f10788-c2e0-4b8f-9146-e11a7e150efc" />

### API 응답 성공
<img width="1037" height="980" alt="image" src="https://github.com/user-attachments/assets/c5aedae9-462e-47fa-ad96-dc8ca098b973" />


## 🗨️ 참고 사항
<!-- 특별히 봐주었으면 하는 부분과 참고해야 할 사항이 있다면 작성해 주세요 -->
<!-- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->