### PR TITLE
feat: RDI 조회 API 구현

### DIFF
--- a/src/main/java/com/onlymeal/domain/rdi/controller/RdiController.java
+++ b/src/main/java/com/onlymeal/domain/rdi/controller/RdiController.java
@@ -1,0 +1,24 @@
+package com.onlymeal.domain.rdi.controller;
+
+import com.onlymeal.domain.rdi.dto.RdiResponse;
+import com.onlymeal.domain.rdi.service.RdiService;
+import com.onlymeal.global.common.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/users/me")
+@RequiredArgsConstructor
+public class RdiController {
+
+    private final RdiService rdiService;
+
+    @GetMapping("/rdi")
+    public ApiResponse<RdiResponse> getRdi(@AuthenticationPrincipal Long userId) {
+        RdiResponse response = rdiService.getRdi(userId);
+        return ApiResponse.success(response);
+    }
+}

--- a/src/main/java/com/onlymeal/domain/rdi/dao/RdiDao.java
+++ b/src/main/java/com/onlymeal/domain/rdi/dao/RdiDao.java
@@ -1,0 +1,9 @@
+package com.onlymeal.domain.rdi.dao;
+
+import com.onlymeal.domain.rdi.entity.RdiStandard;
+import org.apache.ibatis.annotations.Mapper;
+
+@Mapper
+public interface RdiDao {
+    RdiStandard getRdiByGenderAndAge(String gender, int age);
+}

--- a/src/main/java/com/onlymeal/domain/rdi/dto/RdiResponse.java
+++ b/src/main/java/com/onlymeal/domain/rdi/dto/RdiResponse.java
@@ -1,0 +1,31 @@
+package com.onlymeal.domain.rdi.dto;
+
+import com.onlymeal.domain.rdi.entity.RdiStandard;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class RdiResponse {
+    private Double recCalories;
+    private Double recCarbs;
+    private Double recProtein;
+    private Double recFat;
+    private Double recSugars;
+    private Double recSodium;
+
+    public static RdiResponse from(RdiStandard rdiStandard, double totalMultiplier) {
+        return RdiResponse.builder()
+                .recCalories(round(rdiStandard.getRecCalories() * totalMultiplier))
+                .recCarbs(round(rdiStandard.getRecCarbs() * totalMultiplier))
+                .recProtein(round(rdiStandard.getRecProtein() * totalMultiplier))
+                .recFat(round(rdiStandard.getRecFat() * totalMultiplier))
+                .recSugars(round(rdiStandard.getRecSugars()))
+                .recSodium(round(rdiStandard.getRecSodium()))
+                .build();
+    }
+
+    private static double round(double value) {
+        return Math.round(value * 100.0) / 100.0;
+    }
+}

--- a/src/main/java/com/onlymeal/domain/rdi/entity/RdiStandard.java
+++ b/src/main/java/com/onlymeal/domain/rdi/entity/RdiStandard.java
@@ -1,0 +1,19 @@
+package com.onlymeal.domain.rdi.entity;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class RdiStandard {
+    private Long rdiId;
+    private String gender;
+    private Integer ageStart;
+    private Integer ageEnd;
+    private Double recCalories;
+    private Double recCarbs;
+    private Double recProtein;
+    private Double recFat;
+    private Double recSugars;
+    private Double recSodium;
+}

--- a/src/main/java/com/onlymeal/domain/rdi/service/RdiService.java
+++ b/src/main/java/com/onlymeal/domain/rdi/service/RdiService.java
@@ -1,0 +1,69 @@
+package com.onlymeal.domain.rdi.service;
+
+import com.onlymeal.domain.rdi.dao.RdiDao;
+import com.onlymeal.domain.rdi.dto.RdiResponse;
+import com.onlymeal.domain.rdi.entity.RdiStandard;
+import com.onlymeal.domain.user.dao.UserDao;
+import com.onlymeal.domain.user.entity.User;
+import com.onlymeal.global.exception.CustomException;
+import com.onlymeal.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.time.Period;
+
+@Service
+@RequiredArgsConstructor
+public class RdiService {
+
+    private final RdiDao rdiDao;
+    private final UserDao userDao;
+
+    public RdiResponse getRdi(Long userId) {
+        User user = userDao.getUserById(userId);
+
+        if (user == null) {
+            throw new CustomException(ErrorCode.USER_NOT_FOUND);
+        }
+
+        int age = calculateAge(user.getBirthDate());
+        RdiStandard rdiStandard = rdiDao.getRdiByGenderAndAge(user.getGender(), age);
+
+        if (rdiStandard == null) {
+            throw new CustomException(ErrorCode.RDI_NOT_FOUND);
+        }
+
+        double activityMultiplier = getActivityMultiplier(user.getActivityLevel());
+        double goalMultiplier = getGoalMultiplier(user.getTargetGoal());
+        double totalMultiplier = activityMultiplier * goalMultiplier;
+
+        return RdiResponse.from(rdiStandard, totalMultiplier);
+    }
+
+    private int calculateAge(String birthDate) {
+        LocalDate birth = LocalDate.parse(birthDate);
+        LocalDate now = LocalDate.now();
+        return Period.between(birth, now).getYears();
+    }
+
+    private double getActivityMultiplier(String activityLevel) {
+        return switch (activityLevel) {
+            case "SEDENTARY" -> 0.8;
+            case "LOW" -> 0.9;
+            case "MODERATE" -> 1.0;
+            case "ACTIVE" -> 1.1;
+            case "VERY_ACTIVE" -> 1.2;
+            default -> 1.0;
+        };
+    }
+
+    private double getGoalMultiplier(String targetGoal) {
+        return switch (targetGoal) {
+            case "DIET" -> 0.85;
+            case "MAINTAIN" -> 1.0;
+            case "BULK_UP" -> 1.15;
+            default -> 1.0;
+        };
+    }
+}

--- a/src/main/java/com/onlymeal/global/exception/ErrorCode.java
+++ b/src/main/java/com/onlymeal/global/exception/ErrorCode.java
@@ -28,6 +28,9 @@ public enum ErrorCode {
     FOOD_NOT_FOUND(HttpStatus.NOT_FOUND, "음식 정보를 찾을 수 없습니다"),
     KEYWORD_REQUIRED(HttpStatus.BAD_REQUEST, "검색어는 필수입니다"),
 
+    // RDI
+    RDI_NOT_FOUND(HttpStatus.NOT_FOUND, "권장 섭취량 기준을 찾을 수 없습니다"),
+
     // Common
     INVALID_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 요청입니다"),
     INTERNAL_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 오류가 발생했습니다");

--- a/src/main/resources/mappers/RdiDao.xml
+++ b/src/main/resources/mappers/RdiDao.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="com.onlymeal.domain.rdi.dao.RdiDao">
+
+    <select id="getRdiByGenderAndAge" resultType="RdiStandard">
+        SELECT *
+        FROM rdi_standard
+        WHERE gender = #{gender}
+          AND age_start &lt;= #{age}
+          AND age_end &gt;= #{age}
+    </select>
+
+</mapper>


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- close : #28 
<!-- 이슈 완료되었을 때만 close 붙여주세요 --> 

## ✅ 작업 내용
<!-- 이번 PR에서 작업한 내용을 설명해 주세요 -->
- RDI 도메인 생성 (entity, dao, service, controller)
- 나이/성별 기반 기본 RDI 조회
- 활동량/목표에 따른 계수 적용
- 소수점 2자리 반올림 처리

## 📸 스크린샷 
<!-- 실행 결과를 첨부해 주세요 -->

### 성공
<img width="947" height="480" alt="image" src="https://github.com/user-attachments/assets/14156cda-7330-43dd-81fa-f0357b2c0eec" />
## 🗨️ 참고 사항
<!-- 특별히 봐주었으면 하는 부분과 참고해야 할 사항이 있다면 작성해 주세요 -->
<!-- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->