### PR TITLE
feat: 식단 수정 API 구현

### DIFF
--- a/src/main/java/com/onlymeal/domain/meal/controller/MealController.java
+++ b/src/main/java/com/onlymeal/domain/meal/controller/MealController.java
@@ -2,8 +2,11 @@ package com.onlymeal.domain.meal.controller;
 
 import com.onlymeal.domain.meal.dto.MealCreateRequest;
 import com.onlymeal.domain.meal.dto.MealDetailResponse;
+import com.onlymeal.domain.meal.dto.MealUpdateRequest;
 import com.onlymeal.domain.meal.service.MealService;
 import com.onlymeal.global.common.ApiResponse;
+import com.onlymeal.global.exception.CustomException;
+import com.onlymeal.global.exception.ErrorCode;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -32,5 +35,21 @@ public class MealController {
             @PathVariable Long logId,
             @AuthenticationPrincipal Long userId) {
         return ApiResponse.success(mealService.getMealDetail(logId, userId));
+    }
+
+    @PatchMapping("/{logId}")
+    public ApiResponse<Void> updateMeal(
+            @PathVariable Long logId,
+            @AuthenticationPrincipal Long userId,
+            @RequestPart(value = "data", required = false) @Valid MealUpdateRequest request,
+            @RequestPart(value = "image", required = false) MultipartFile image) {
+
+        if (request == null && image == null) {
+            throw new CustomException(ErrorCode.INVALID_REQUEST);
+        }
+
+        mealService.updateMeal(logId, userId, request, image);
+
+        return ApiResponse.success(null);
     }
 }

--- a/src/main/java/com/onlymeal/domain/meal/dao/MealDao.java
+++ b/src/main/java/com/onlymeal/domain/meal/dao/MealDao.java
@@ -20,4 +20,10 @@ public interface MealDao {
     MealLog getMealLogById(@Param("logId") Long logId);
 
     List<MealItem> getMealItemsByLogId(@Param("logId") Long logId);
+
+    void updateMealType(@Param("logId") Long logId, @Param("mealType") String mealType);
+
+    void updateMealImage(@Param("logId") Long logId, @Param("imageUrl") String imageUrl);
+
+    void deleteMealItems(@Param("logId") Long logId);
 }

--- a/src/main/java/com/onlymeal/domain/meal/dto/MealUpdateRequest.java
+++ b/src/main/java/com/onlymeal/domain/meal/dto/MealUpdateRequest.java
@@ -1,0 +1,18 @@
+package com.onlymeal.domain.meal.dto;
+
+import jakarta.validation.Valid;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class MealUpdateRequest {
+    private String mealType;
+
+    @Valid
+    private List<MealItemRequest> items;
+}

--- a/src/main/java/com/onlymeal/domain/meal/service/MealService.java
+++ b/src/main/java/com/onlymeal/domain/meal/service/MealService.java
@@ -5,6 +5,7 @@ import com.onlymeal.domain.meal.dao.MealDao;
 import com.onlymeal.domain.meal.dto.MealCreateRequest;
 import com.onlymeal.domain.meal.dto.MealDetailResponse;
 import com.onlymeal.domain.meal.dto.MealItemRequest;
+import com.onlymeal.domain.meal.dto.MealUpdateRequest;
 import com.onlymeal.domain.meal.entity.MealItem;
 import com.onlymeal.domain.meal.entity.MealLog;
 import com.onlymeal.global.exception.CustomException;
@@ -59,6 +60,51 @@ public class MealService {
         List<MealItem> mealItems = mealDao.getMealItemsByLogId(logId);
 
         return MealDetailResponse.of(mealLog, mealItems);
+    }
+
+    @Transactional
+    public void updateMeal(Long logId, Long userId, MealUpdateRequest request, MultipartFile image) {
+        MealLog mealLog = mealDao.getMealLogById(logId);
+
+        if (mealLog == null) {
+            throw new CustomException(ErrorCode.MEAL_NOT_FOUND);
+        }
+
+        if (!mealLog.getUserId().equals(userId)) {
+            throw new CustomException(ErrorCode.FORBIDDEN);
+        }
+
+        if (image != null && !image.isEmpty()) {
+            fileStorage.delete(mealLog.getImageUrl());
+
+            String currentMealType = (request != null && request.getMealType() != null)
+                    ? request.getMealType()
+                    : mealLog.getMealType();
+
+            String newImageUrl = fileStorage.store(image, userId, currentMealType);
+            mealDao.updateMealImage(logId, newImageUrl);
+        }
+
+        if (request == null) {
+            return;
+        }
+
+        if (request.getMealType() != null && !request.getMealType().equals(mealLog.getMealType())) {
+            if (mealDao.existsMealLog(userId, mealLog.getMealDate(), request.getMealType())) {
+                throw new CustomException(ErrorCode.DUPLICATE_MEAL);
+            }
+            mealDao.updateMealType(logId, request.getMealType());
+        }
+
+        if (request.getItems() != null) {
+            validateFoodIds(request.getItems());
+            mealDao.deleteMealItems(logId);
+
+            List<MealItem> mealItems = MealItem.createList(logId, request.getItems());
+            for (MealItem item : mealItems) {
+                mealDao.insertMealItem(item);
+            }
+        }
     }
 
     private void validateFoodIds(List<MealItemRequest> items) {

--- a/src/main/resources/mappers/MealDao.xml
+++ b/src/main/resources/mappers/MealDao.xml
@@ -22,7 +22,9 @@
     </select>
 
     <select id="getMealLogById" resultType="MealLog">
-        SELECT * FROM meal_logs WHERE log_id = #{logId}
+        SELECT *
+        FROM meal_logs
+        WHERE log_id = #{logId}
     </select>
 
     <select id="existsMealLog" resultType="boolean">
@@ -32,4 +34,22 @@
           AND meal_date = #{mealDate}
           AND meal_type = #{mealType}
     </select>
+
+    <update id="updateMealType">
+        UPDATE meal_logs
+        SET meal_type = #{mealType}
+        WHERE log_id = #{logId}
+    </update>
+
+    <update id="updateMealImage">
+        UPDATE meal_logs
+        SET image_url = #{imageUrl}
+        WHERE log_id = #{logId}
+    </update>
+
+    <delete id="deleteMealItems">
+        DELETE
+        FROM meal_items
+        WHERE log_id = #{logId}
+    </delete>
 </mapper>


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- close : #33
<!-- 이슈 완료되었을 때만 close 붙여주세요 --> 

## ✅ 작업 내용
<!-- 이번 PR에서 작업한 내용을 설명해 주세요 -->
- Service에 식단 수정 비즈니스 로직 구현
  - 이미지 교체 및 기존 파일 삭제 처리
  - 식사 구분(MealType) 변경 시 중복 검사
  - 음식 항목(Items) 전체 교체 로직 적용
## 📸 스크린샷 
<!-- 실행 결과를 첨부해 주세요 -->

## 🗨️ 참고 사항
<!-- 특별히 봐주었으면 하는 부분과 참고해야 할 사항이 있다면 작성해 주세요 -->
<!-- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->