### PR TITLE
feat: 식단 기간별 조회

### DIFF
--- a/src/main/java/com/onlymeal/domain/meal/controller/MealController.java
+++ b/src/main/java/com/onlymeal/domain/meal/controller/MealController.java
@@ -1,9 +1,6 @@
 package com.onlymeal.domain.meal.controller;
 
-import com.onlymeal.domain.meal.dto.MealCreateRequest;
-import com.onlymeal.domain.meal.dto.MealDashboardResponse;
-import com.onlymeal.domain.meal.dto.MealDetailResponse;
-import com.onlymeal.domain.meal.dto.MealUpdateRequest;
+import com.onlymeal.domain.meal.dto.*;
 import com.onlymeal.domain.meal.service.MealService;
 import com.onlymeal.global.common.ApiResponse;
 import com.onlymeal.global.exception.CustomException;
@@ -15,6 +12,7 @@ import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.time.LocalDate;
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/meals")
@@ -71,6 +69,18 @@ public class MealController {
             @RequestParam LocalDate date) {
 
         MealDashboardResponse response = mealService.getDashboard(userId, date.toString());
+        return ApiResponse.success(response);
+    }
+
+    @GetMapping("/calendar")
+    public ApiResponse<List<DailyMealStatus>> getMonthlyMealStatus(
+            @AuthenticationPrincipal Long userId,
+            @RequestParam LocalDate startDate,
+            @RequestParam LocalDate endDate) {
+
+        List<DailyMealStatus> response = mealService.getDailyMealStatus(
+                userId, startDate.toString(), endDate.toString());
+
         return ApiResponse.success(response);
     }
 }

--- a/src/main/java/com/onlymeal/domain/meal/dao/MealDao.java
+++ b/src/main/java/com/onlymeal/domain/meal/dao/MealDao.java
@@ -1,5 +1,6 @@
 package com.onlymeal.domain.meal.dao;
 
+import com.onlymeal.domain.meal.dto.DailyMealStatus;
 import com.onlymeal.domain.meal.entity.MealItem;
 import com.onlymeal.domain.meal.entity.MealLog;
 import org.apache.ibatis.annotations.Mapper;
@@ -30,4 +31,8 @@ public interface MealDao {
     void deleteMealLog(@Param("logId") Long logId);
 
     List<MealLog> getMealLogsByDate(@Param("userId") Long userId, @Param("date") String date);
+
+    List<DailyMealStatus> getDailyMealStatus(@Param("userId") Long userId,
+                                             @Param("startDate") String startDate,
+                                             @Param("endDate") String endDate);
 }

--- a/src/main/java/com/onlymeal/domain/meal/dto/DailyMealStatus.java
+++ b/src/main/java/com/onlymeal/domain/meal/dto/DailyMealStatus.java
@@ -1,0 +1,18 @@
+package com.onlymeal.domain.meal.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class DailyMealStatus {
+    private String date;
+    private boolean hasBreakfast;
+    private boolean hasLunch;
+    private boolean hasDinner;
+    private boolean hasSnack;
+}

--- a/src/main/java/com/onlymeal/domain/meal/service/MealService.java
+++ b/src/main/java/com/onlymeal/domain/meal/service/MealService.java
@@ -117,6 +117,10 @@ public class MealService {
         return new MealDashboardResponse(meals, dailySummary);
     }
 
+    public List<DailyMealStatus> getDailyMealStatus(Long userId, String startDate, String endDate) {
+        return mealDao.getDailyMealStatus(userId, startDate, endDate);
+    }
+
     private void validateFoodIds(List<MealItemRequest> items) {
         for (MealItemRequest item : items) {
             if (foodDao.getFoodById(item.getFoodId()) == null) {

--- a/src/main/resources/mappers/MealDao.xml
+++ b/src/main/resources/mappers/MealDao.xml
@@ -110,4 +110,18 @@
           AND ml.meal_date = #{date}
         ORDER BY ml.created_at, mi.item_id
     </select>
+
+    <select id="getDailyMealStatus" resultType="com.onlymeal.domain.meal.dto.DailyMealStatus">
+        SELECT
+            meal_date AS date,
+            MAX(IF(meal_type = 'BREAKFAST', 1, 0)) AS hasBreakfast,
+            MAX(IF(meal_type = 'LUNCH',     1, 0)) AS hasLunch,
+            MAX(IF(meal_type = 'DINNER',    1, 0)) AS hasDinner,
+            MAX(IF(meal_type = 'SNACK',     1, 0)) AS hasSnack
+        FROM meal_logs
+        WHERE user_id = #{userId}
+          AND meal_date BETWEEN #{startDate} AND #{endDate}
+        GROUP BY meal_date
+        ORDER BY meal_date
+    </select>
 </mapper>


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- #[Issue number]
- close : #31 
<!-- 이슈 완료되었을 때만 close 붙여주세요 --> 

## ✅ 작업 내용
<!-- 이번 PR에서 작업한 내용을 설명해 주세요 -->
- 특정 기간(startDate ~ endDate)의 날짜별 식단 존재 여부 조회 기능 구현
- DB 집계 쿼리(GROUP BY, MAX)를 사용하여 별도 변환 로직 없이 성능 최적화
- DailyMealStatus DTO 추가 (hasBreakfast, hasLunch 등 불리언 필드 포함)

## 📸 스크린샷 
<!-- 실행 결과를 첨부해 주세요 -->

```
{
    "success": true,
    "data": [
        {
            "date": "2025-12-07",
            "hasBreakfast": true,
            "hasLunch": false,
            "hasDinner": false,
            "hasSnack": false
        },
        {
            "date": "2025-12-09",
            "hasBreakfast": false,
            "hasLunch": true,
            "hasDinner": true,
            "hasSnack": false
        },
        {
            "date": "2025-12-11",
            "hasBreakfast": false,
            "hasLunch": false,
            "hasDinner": false,
            "hasSnack": true
        },
        {
            "date": "2025-12-13",
            "hasBreakfast": true,
            "hasLunch": false,
            "hasDinner": false,
            "hasSnack": false
        }
    ]
}
```
## 🗨️ 참고 사항
<!-- 특별히 봐주었으면 하는 부분과 참고해야 할 사항이 있다면 작성해 주세요 -->
<!-- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->