### PR TITLE
feat: 일일 식단 분석 API 구현

### DIFF
--- a/src/main/java/com/onlymeal/domain/meal/controller/MealController.java
+++ b/src/main/java/com/onlymeal/domain/meal/controller/MealController.java
@@ -1,12 +1,16 @@
 package com.onlymeal.domain.meal.controller;
 
 import com.onlymeal.domain.meal.dto.*;
+import com.onlymeal.domain.meal.entity.DailyAnalysis;
 import com.onlymeal.domain.meal.service.MealService;
+import com.onlymeal.domain.rdi.dto.RdiResponse;
+import com.onlymeal.domain.rdi.service.RdiService;
 import com.onlymeal.global.common.ApiResponse;
 import com.onlymeal.global.exception.CustomException;
 import com.onlymeal.global.exception.ErrorCode;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
@@ -20,6 +24,7 @@ import java.util.List;
 public class MealController {
 
     private final MealService mealService;
+    private final RdiService rdiService;
 
     @PostMapping
     public ApiResponse<Void> createMeal(
@@ -82,5 +87,28 @@ public class MealController {
                 userId, startDate.toString(), endDate.toString());
 
         return ApiResponse.success(response);
+    }
+
+    @GetMapping("/daily-analysis")
+    public ResponseEntity<?> getDailyAnalysis(
+            @AuthenticationPrincipal Long userId,
+            @RequestParam LocalDate date) {
+
+        DailyAnalysis analysis = mealService.getDailyAnalysis(userId, date.toString());
+
+        if (analysis == null) {
+            return ResponseEntity.noContent().build();
+        }
+
+        RdiResponse rdi = rdiService.getRdi(userId);
+        return ResponseEntity.ok(ApiResponse.success(DailyAnalysisResponse.of(analysis, rdi)));
+    }
+
+    @PostMapping("/daily-analysis")
+    public ApiResponse<DailyAnalysisResponse> analyzeDailyMeal(
+            @AuthenticationPrincipal Long userId,
+            @RequestParam LocalDate date) {
+
+        return ApiResponse.success(mealService.analyzeDailyMeal(userId, date.toString()));
     }
 }

--- a/src/main/java/com/onlymeal/domain/meal/dao/DailyAnalysisDao.java
+++ b/src/main/java/com/onlymeal/domain/meal/dao/DailyAnalysisDao.java
@@ -1,0 +1,14 @@
+package com.onlymeal.domain.meal.dao;
+
+import com.onlymeal.domain.meal.entity.DailyAnalysis;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+@Mapper
+public interface DailyAnalysisDao {
+
+    DailyAnalysis findByUserIdAndDate(@Param("userId") Long userId,
+                                      @Param("analysisDate") String analysisDate);
+
+    void upsertDailyAnalysis(DailyAnalysis dailyAnalysis);
+}

--- a/src/main/java/com/onlymeal/domain/meal/dto/DailyAnalysisResponse.java
+++ b/src/main/java/com/onlymeal/domain/meal/dto/DailyAnalysisResponse.java
@@ -1,0 +1,68 @@
+package com.onlymeal.domain.meal.dto;
+
+import com.onlymeal.domain.meal.entity.DailyAnalysis;
+import com.onlymeal.domain.rdi.dto.RdiResponse;
+import lombok.*;
+
+import java.time.LocalDate;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class DailyAnalysisResponse {
+    private LocalDate analysisDate;
+
+    // 일일 섭취량
+    private Double totalCalories;
+    private Double totalCarbs;
+    private Double totalProtein;
+    private Double totalFat;
+    private Double totalSugars;
+    private Double totalSodium;
+
+    // RDI 기준값
+    private Double recCalories;
+    private Double recCarbs;
+    private Double recProtein;
+    private Double recFat;
+    private Double recSugars;
+    private Double recSodium;
+
+    // 가우시안 점수
+    private Double totalScore;
+    private Double scoreCalories;
+    private Double scoreCarbs;
+    private Double scoreProtein;
+    private Double scoreFat;
+    private Double scoreSugars;
+    private Double scoreSodium;
+
+    public static DailyAnalysisResponse of(DailyAnalysis analysis, RdiResponse rdi) {
+        return DailyAnalysisResponse.builder()
+                .analysisDate(analysis.getAnalysisDate())
+                // 섭취량
+                .totalCalories(analysis.getTotalCalories())
+                .totalCarbs(analysis.getTotalCarbs())
+                .totalProtein(analysis.getTotalProtein())
+                .totalFat(analysis.getTotalFat())
+                .totalSugars(analysis.getTotalSugars())
+                .totalSodium(analysis.getTotalSodium())
+                // RDI 기준
+                .recCalories(rdi.getRecCalories())
+                .recCarbs(rdi.getRecCarbs())
+                .recProtein(rdi.getRecProtein())
+                .recFat(rdi.getRecFat())
+                .recSugars(rdi.getRecSugars())
+                .recSodium(rdi.getRecSodium())
+                // 점수
+                .totalScore(analysis.getTotalScore())
+                .scoreCalories(analysis.getScoreCalories())
+                .scoreCarbs(analysis.getScoreCarbs())
+                .scoreProtein(analysis.getScoreProtein())
+                .scoreFat(analysis.getScoreFat())
+                .scoreSugars(analysis.getScoreSugars())
+                .scoreSodium(analysis.getScoreSodium())
+                .build();
+    }
+}

--- a/src/main/java/com/onlymeal/domain/meal/entity/DailyAnalysis.java
+++ b/src/main/java/com/onlymeal/domain/meal/entity/DailyAnalysis.java
@@ -1,0 +1,35 @@
+package com.onlymeal.domain.meal.entity;
+
+import lombok.*;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class DailyAnalysis {
+    private Long analysisId;
+    private Long userId;
+    private LocalDate analysisDate;
+
+    private Double totalCalories;
+    private Double totalCarbs;
+    private Double totalProtein;
+    private Double totalFat;
+    private Double totalSugars;
+    private Double totalSodium;
+
+    private Double totalScore;
+    private Double scoreCalories;
+    private Double scoreCarbs;
+    private Double scoreProtein;
+    private Double scoreFat;
+    private Double scoreSugars;
+    private Double scoreSodium;
+
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/onlymeal/domain/meal/service/MealService.java
+++ b/src/main/java/com/onlymeal/domain/meal/service/MealService.java
@@ -1,8 +1,10 @@
 package com.onlymeal.domain.meal.service;
 
 import com.onlymeal.domain.food.dao.FoodDao;
+import com.onlymeal.domain.meal.dao.DailyAnalysisDao;
 import com.onlymeal.domain.meal.dao.MealDao;
 import com.onlymeal.domain.meal.dto.*;
+import com.onlymeal.domain.meal.entity.DailyAnalysis;
 import com.onlymeal.domain.meal.entity.MealItem;
 import com.onlymeal.domain.meal.entity.MealLog;
 import com.onlymeal.domain.rdi.dto.RdiResponse;
@@ -15,6 +17,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -26,6 +29,7 @@ public class MealService {
     private final FoodDao foodDao;
     private final FileStorage fileStorage;
     private final RdiService rdiService;
+    private final DailyAnalysisDao dailyAnalysisDao;
 
     @Transactional
     public void createMeal(Long userId, MealCreateRequest request, MultipartFile image) {
@@ -169,5 +173,32 @@ public class MealService {
                 mealDao.insertMealItem(item);
             }
         }
+    }
+
+    public DailyAnalysis getDailyAnalysis(Long userId, String date) {
+        return dailyAnalysisDao.findByUserIdAndDate(userId, date);
+    }
+
+    @Transactional
+    public DailyAnalysisResponse analyzeDailyMeal(Long userId, String date) {
+        List<MealLog> mealLogs = mealDao.getMealLogsByDate(userId, date);
+
+        if (mealLogs.isEmpty()) {
+            throw new CustomException(ErrorCode.NO_MEAL_FOR_DATE);
+        }
+
+        RdiResponse rdi = rdiService.getRdi(userId);
+
+        NutrientAccumulator accumulator = new NutrientAccumulator();
+        for (MealLog log : mealLogs) {
+            for (MealItem item : log.getMealItems()) {
+                accumulator.add(item);
+            }
+        }
+
+        DailyAnalysis analysis = accumulator.toDailyAnalysis(userId, LocalDate.parse(date), rdi);
+        dailyAnalysisDao.upsertDailyAnalysis(analysis);
+
+        return DailyAnalysisResponse.of(analysis, rdi);
     }
 }

--- a/src/main/java/com/onlymeal/domain/meal/service/NutrientAccumulator.java
+++ b/src/main/java/com/onlymeal/domain/meal/service/NutrientAccumulator.java
@@ -1,10 +1,15 @@
 package com.onlymeal.domain.meal.service;
 
 import com.onlymeal.domain.meal.dto.DailySummary;
+import com.onlymeal.domain.meal.entity.DailyAnalysis;
 import com.onlymeal.domain.meal.entity.MealItem;
 import com.onlymeal.domain.rdi.dto.RdiResponse;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDate;
+
+@Getter
 @NoArgsConstructor
 public class NutrientAccumulator {
     private double totalCalories = 0;
@@ -25,6 +30,34 @@ public class NutrientAccumulator {
         this.totalFat += item.getFood().getFatG() * multiplier;
         this.totalSugars += item.getFood().getSugarsG() * multiplier;
         this.totalSodium += item.getFood().getSodiumMg() * multiplier;
+    }
+
+    public DailyAnalysis toDailyAnalysis(Long userId, LocalDate date, RdiResponse rdi) {
+        double scoreCalories = gaussianScore(totalCalories, rdi.getRecCalories());
+        double scoreCarbs = gaussianScore(totalCarbs, rdi.getRecCarbs());
+        double scoreProtein = gaussianScore(totalProtein, rdi.getRecProtein());
+        double scoreFat = gaussianScore(totalFat, rdi.getRecFat());
+        double scoreSugars = gaussianScore(totalSugars, rdi.getRecSugars());
+        double scoreSodium = gaussianScoreUpperLimit(totalSodium, rdi.getRecSodium());
+        double totalScore = (scoreCalories + scoreCarbs + scoreProtein + scoreFat + scoreSugars + scoreSodium) / 6.0;
+
+        DailyAnalysis analysis = new DailyAnalysis();
+        analysis.setUserId(userId);
+        analysis.setAnalysisDate(date);
+        analysis.setTotalCalories(round(totalCalories));
+        analysis.setTotalCarbs(round(totalCarbs));
+        analysis.setTotalProtein(round(totalProtein));
+        analysis.setTotalFat(round(totalFat));
+        analysis.setTotalSugars(round(totalSugars));
+        analysis.setTotalSodium(round(totalSodium));
+        analysis.setTotalScore(round(totalScore));
+        analysis.setScoreCalories(round(scoreCalories));
+        analysis.setScoreCarbs(round(scoreCarbs));
+        analysis.setScoreProtein(round(scoreProtein));
+        analysis.setScoreFat(round(scoreFat));
+        analysis.setScoreSugars(round(scoreSugars));
+        analysis.setScoreSodium(round(scoreSodium));
+        return analysis;
     }
 
     public DailySummary toDailySummary(RdiResponse rdi) {
@@ -57,5 +90,19 @@ public class NutrientAccumulator {
     private int calculatePercent(double current, double target) {
         if (target == 0) return 0;
         return (int) (current / target * 100);
+    }
+
+    private double gaussianScore(double actual, double target) {
+        if (target == 0) return 0;
+        double ratio = actual / target;
+        double sigma = 0.3;
+        return 100 * Math.exp(-Math.pow(ratio - 1.0, 2) / (2 * sigma * sigma));
+    }
+
+    private double gaussianScoreUpperLimit(double actual, double target) {
+        if (target == 0) return 0;
+        double ratio = actual / target;
+        if (ratio <= 1.0) return 100;
+        return gaussianScore(actual, target);
     }
 }

--- a/src/main/java/com/onlymeal/global/exception/ErrorCode.java
+++ b/src/main/java/com/onlymeal/global/exception/ErrorCode.java
@@ -18,9 +18,11 @@ public enum ErrorCode {
     TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "토큰이 만료되었습니다"),
     TOKEN_INVALID(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다"),
     FORBIDDEN(HttpStatus.FORBIDDEN, "접근 권한이 없습니다"),
+
     // Meal
     MEAL_NOT_FOUND(HttpStatus.NOT_FOUND, "식단 기록을 찾을 수 없습니다"),
     DUPLICATE_MEAL(HttpStatus.CONFLICT, "해당 날짜에 이미 등록된 식사가 있습니다"),
+    NO_MEAL_FOR_DATE(HttpStatus.BAD_REQUEST, "해당 날짜에 등록된 식단이 없습니다"),
 
     // Feed
     FEED_NOT_FOUND(HttpStatus.NOT_FOUND, "피드를 찾을 수 없습니다"),

--- a/src/main/resources/mappers/DailyAnalysisDao.xml
+++ b/src/main/resources/mappers/DailyAnalysisDao.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="com.onlymeal.domain.meal.dao.DailyAnalysisDao">
+
+    <select id="findByUserIdAndDate" resultType="com.onlymeal.domain.meal.entity.DailyAnalysis">
+        SELECT analysis_id, user_id, analysis_date,
+               total_calories, total_carbs, total_protein, total_fat, total_sugars, total_sodium,
+               total_score, score_calories, score_carbs, score_protein, score_fat, score_sugars, score_sodium,
+               created_at, updated_at
+        FROM daily_analysis
+        WHERE user_id = #{userId}
+          AND analysis_date = #{analysisDate}
+    </select>
+
+    <insert id="upsertDailyAnalysis">
+        INSERT INTO daily_analysis (
+            user_id, analysis_date,
+            total_calories, total_carbs, total_protein, total_fat, total_sugars, total_sodium,
+            total_score, score_calories, score_carbs, score_protein, score_fat, score_sugars, score_sodium
+        ) VALUES (
+                     #{userId}, #{analysisDate},
+                     #{totalCalories}, #{totalCarbs}, #{totalProtein}, #{totalFat}, #{totalSugars}, #{totalSodium},
+                     #{totalScore}, #{scoreCalories}, #{scoreCarbs}, #{scoreProtein}, #{scoreFat}, #{scoreSugars}, #{scoreSodium}
+                 )
+        ON DUPLICATE KEY UPDATE
+                             total_calories = VALUES(total_calories),
+                             total_carbs = VALUES(total_carbs),
+                             total_protein = VALUES(total_protein),
+                             total_fat = VALUES(total_fat),
+                             total_sugars = VALUES(total_sugars),
+                             total_sodium = VALUES(total_sodium),
+                             total_score = VALUES(total_score),
+                             score_calories = VALUES(score_calories),
+                             score_carbs = VALUES(score_carbs),
+                             score_protein = VALUES(score_protein),
+                             score_fat = VALUES(score_fat),
+                             score_sugars = VALUES(score_sugars),
+                             score_sodium = VALUES(score_sodium),
+                             updated_at = CURRENT_TIMESTAMP
+    </insert>
+
+</mapper>


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- close : #44 


## ✅ 작업 내용
- `daily_analysis` 테이블 및 Entity/DTO/DAO 추가
- GET `/meals/daily-analysis`: 분석 데이터 조회 (없으면 204 No Content)
- POST `/meals/daily-analysis`: 분석 실행 (UPSERT)
- 가우시안 점수 계산 로직 구현 (σ=0.3)
- `NutrientAccumulator`에 `toDailyAnalysis()` 메서드 추가
- `NO_MEAL_FOR_DATE` ErrorCode 추가

## 📸 스크린샷 

### 성공
```json
{
    "success": true,
    "data": {
        "analysisDate": "2025-12-22",
        "totalCalories": 3218.5,
        "totalCarbs": 381.0,
        "totalProtein": 65.4,
        "totalFat": 164.2,
        "totalSugars": 158.0,
        "totalSodium": 1294.0,
        "recCalories": 2224.94,
        "recCarbs": 287.41,
        "recProtein": 85.64,
        "recFat": 65.85,
        "recSugars": 61.32,
        "recSodium": 3957.7,
        "totalScore": 43.6,
        "scoreCalories": 33.0,
        "scoreCarbs": 55.5,
        "scoreProtein": 73.3,
        "scoreFat": 0.0,
        "scoreSugars": 0.0,
        "scoreSodium": 100.0
    }
}
```

### 실패(식단정보 없음)
```json
{
    "success": false,
    "error": {
        "code": "NO_MEAL_FOR_DATE",
        "message": "해당 날짜에 등록된 식단이 없습니다"
    }
}
```

## 🗨️ 참고 사항
- 분석은 사용자가 재분석 버튼을 눌렀을 때만 실행됩니다 (식단 등록/수정/삭제 시 자동 재계산 X)
- 나트륨은 상한선 기준으로 점수 계산 (낮을수록 100점)