### PR TITLE
feat: 식단 상세 조회 영양소 합계 추가

### DIFF
--- a/src/main/java/com/onlymeal/domain/meal/dto/MealDetailResponse.java
+++ b/src/main/java/com/onlymeal/domain/meal/dto/MealDetailResponse.java
@@ -2,6 +2,7 @@ package com.onlymeal.domain.meal.dto;
 
 import com.onlymeal.domain.meal.entity.MealItem;
 import com.onlymeal.domain.meal.entity.MealLog;
+import com.onlymeal.domain.meal.service.NutrientAccumulator;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -16,10 +17,22 @@ public class MealDetailResponse {
     private String imageUrl;
     private List<MealItemResponse> items;
 
+    private Double totalCalories;
+    private Double totalCarbs;
+    private Double totalProtein;
+    private Double totalFat;
+    private Double totalSugars;
+    private Double totalSodium;
+
     public static MealDetailResponse of(MealLog mealLog, List<MealItem> mealItems) {
         List<MealItemResponse> items = mealItems.stream()
                 .map(MealItemResponse::from)
                 .toList();
+
+        NutrientAccumulator accumulator = new NutrientAccumulator();
+        for (MealItem item : mealItems) {
+            accumulator.add(item);
+        }
 
         return MealDetailResponse.builder()
                 .logId(mealLog.getLogId())
@@ -27,6 +40,16 @@ public class MealDetailResponse {
                 .mealDate(mealLog.getMealDate())
                 .imageUrl(mealLog.getImageUrl())
                 .items(items)
+                .totalCalories(round(accumulator.getTotalCalories()))
+                .totalCarbs(round(accumulator.getTotalCarbs()))
+                .totalProtein(round(accumulator.getTotalProtein()))
+                .totalFat(round(accumulator.getTotalFat()))
+                .totalSugars(round(accumulator.getTotalSugars()))
+                .totalSodium(round(accumulator.getTotalSodium()))
                 .build();
+    }
+
+    private static double round(double value) {
+        return Math.round(value * 100.0) / 100.0;
     }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

## ✅ 작업 내용
- `MealDetailResponse`에 영양소 합계 필드 추가
  - totalCalories, totalCarbs, totalProtein, totalFat, totalSugars, totalSodium
- 소수점 둘째자리 반올림 처리

## 📸 스크린샷 
```json
{
    "success": true,
    "data": {
        "logId": 15,
        "mealType": "BREAKFAST",
        "mealDate": "2025-12-07",
        "imageUrl": "/uploads/meals/1_BREAKFAST_90dca3ad-215e-4e64-8292-6cd749057f96.jpg",
        "items": [
            {
                "itemId": 1,
                "foodId": 1,
                "foodName": "국밥_돼지머리",
                "inputType": "RATIO",
                "inputAmount": 1.0
            }
        ],
        "totalCalories": 1233.0,
        "totalCarbs": 143.46,
        "totalProtein": 60.3,
        "totalFat": 46.44,
        "totalSugars": 1.44,
        "totalSodium": 1629.0
    }
}
```

## 🗨️ 참고 사항
- `NutrientAccumulator` 재사용하여 영양소 합계 계산